### PR TITLE
Support for multiple drivers

### DIFF
--- a/perfecto-reporting/perfecto/client/PerfectoReportiumClient.py
+++ b/perfecto-reporting/perfecto/client/PerfectoReportiumClient.py
@@ -1,6 +1,6 @@
 from .constants import *
 from .PerfectoDeprecator import deprecated
-
+import json
 
 class PerfectoReportiumClient:
     """
@@ -14,6 +14,26 @@ class PerfectoReportiumClient:
         self.perfecto_execution_context = perfecto_execution_context
         self.webdriver = perfecto_execution_context.webdriver
         self.started = False
+        driverCount = 0
+        # Check whether we got a list of webdrivers
+        if isinstance(self.webdriver, list):
+            externalIdAliases = []
+            for driver in self.webdriver:
+                driverCount = driverCount + 1
+                externalIDs = {
+                    'externalId':driver.desired_capabilities['executionId'],
+                    'alias':"perfectoRemote" + str(driverCount)
+                }
+                externalIdAliases.append(externalIDs)
+            # Convert the list into JSON format
+            final_data = json.dumps(externalIdAliases)
+            params = {}
+            params['externalIdAliases'] = final_data
+            try:
+                self.execute_script('mobile:execution:multiple',params)
+            except Exception as e:
+                print("Error while creating multiple driver report")
+        
 
     def test_start(self, name, context):
         """
@@ -159,4 +179,7 @@ class PerfectoReportiumClient:
         :param params: commands parameters
         :return: command's return value
         """
-        return self.webdriver.execute_script(script, params)
+        if isinstance(self.webdriver, list):
+            return self.webdriver[0].execute_script(script, params)
+        else:
+            return self.webdriver.execute_script(script, params)

--- a/perfecto-reporting/perfecto/client/PerfectoReportiumClient.py
+++ b/perfecto-reporting/perfecto/client/PerfectoReportiumClient.py
@@ -14,9 +14,8 @@ class PerfectoReportiumClient:
         self.perfecto_execution_context = perfecto_execution_context
         self.webdriver = perfecto_execution_context.webdriver
         self.started = False
-        driverCount = 0
-        # Check whether we got a list of webdrivers
         if isinstance(self.webdriver, list):
+            driverCount = 0
             externalIdAliases = []
             for driver in self.webdriver:
                 driverCount = driverCount + 1
@@ -25,14 +24,14 @@ class PerfectoReportiumClient:
                     'alias':"perfectoRemote" + str(driverCount)
                 }
                 externalIdAliases.append(externalIDs)
-            # Convert the list into JSON format
-            final_data = json.dumps(externalIdAliases)
+            finalData = json.dumps(externalIdAliases)
             params = {}
-            params['externalIdAliases'] = final_data
+            params['externalIdAliases'] = finalData
+            self.started = True
             try:
                 self.execute_script('mobile:execution:multiple',params)
-            except Exception as e:
-                print("Error while creating multiple driver report")
+            except Exception as e: 
+                pass
         
 
     def test_start(self, name, context):


### PR DESCRIPTION
Added logic to support multiple drivers. Now we can pass eith single webdriver object or a List of webdrivers while creating perfecto_execution_context and Reportium client will support it.

**Report:**
**2 drivers:**https://ps.app.perfectomobile.com/reporting/test/d8a56639-5b86-4c84-b55a-ea33c8785c73
**1 driver:** https://ps.app.perfectomobile.com/reporting/test/74f149b0-454a-446f-a061-faaee888c1ec